### PR TITLE
Tweaks to jitsi ports

### DIFF
--- a/net/jicofo/Makefile
+++ b/net/jicofo/Makefile
@@ -40,7 +40,7 @@ do-build:
 do-install:
 	${INSTALL_DATA_DIR} ${PREFIX}/bin ${PREFIX}/share/jicofo/lib ${MODJAVA_JAR_DIR}
 	${SUBST_PROGRAM} ${FILESDIR}/jicofo.sh ${PREFIX}/bin/jicofo
-	${SUBST_DATA} ${FILESDIR}/jicofo.in.sh ${PREFIX}/share/jicofo/jicofo.in.sh \
+	${SUBST_DATA} ${FILESDIR}/jicofo.in.sh ${PREFIX}/share/jicofo/jicofo.in.sh.sample \
 	    ${FILESDIR}/jicofo.conf ${PREFIX}/share/jicofo/jicofo.conf.sample
 	${INSTALL_DATA} ${WRKSRC}/lib/logging.properties \
 	    ${PREFIX}/share/jicofo/lib/logging.properties.sample

--- a/net/jicofo/Makefile
+++ b/net/jicofo/Makefile
@@ -1,4 +1,4 @@
-COMMENT =	Server side focus component used in Jitsi Meet conferences
+COMMENT =	server-side focus component used in Jitsi Meet conferences
 
 CATEGORIES =	net
 
@@ -9,7 +9,7 @@ GH_ACCOUNT =	jitsi
 GH_PROJECT =	jicofo
 GH_TAGNAME =	jitsi-meet_7648
 
-DISTFILES +=	${DISTNAME}${EXTRACT_SUFX}
+DISTFILES +=	${GH_DISTFILE}
 
 # vendor maven dependencies
 MASTER_SITES7 =	https://files.bsd.ac/openbsd-distfiles/
@@ -17,6 +17,7 @@ DISTFILES +=	jicofo-deps-${VERSION}.tgz:7
 
 MAINTAINER =	Philipp Buehler <pb-openbsd@sysfive.com>, \
 		Aisha Tammy <openbsd@aisha.cc>
+
 # Apache-2.0
 PERMIT_PACKAGE =	Yes
 
@@ -34,7 +35,7 @@ MAVEN_REPO=	-Dmaven.repo.local=${WRKDIR}/m2
 
 do-build:
 	cd ${WRKSRC} && \
-		env -i ${MAKE_ENV} mvn ${MAVEN_REPO} ${MAVEN_ARGS} package
+		${SETENV} ${MAKE_ENV} mvn ${MAVEN_REPO} ${MAVEN_ARGS} package
 
 do-install:
 	${INSTALL_DATA_DIR} ${PREFIX}/bin ${PREFIX}/share/jicofo/lib ${MODJAVA_JAR_DIR}
@@ -45,6 +46,5 @@ do-install:
 	${INSTALL_DATA} ${WRKSRC}/jicofo.in.sh ${PREFIX}/share/jicofo/
 	${INSTALL_DATA} ${WRKSRC}/lib/logging.properties ${PREFIX}/share/jicofo/lib/
 	${INSTALL_DATA} ${WRKSRC}/target/jicofo-1.1-SNAPSHOT-jar-with-dependencies.jar ${MODJAVA_JAR_DIR}/jicofo.jar
-
 
 .include <bsd.port.mk>

--- a/net/jicofo/Makefile
+++ b/net/jicofo/Makefile
@@ -39,12 +39,11 @@ do-build:
 
 do-install:
 	${INSTALL_DATA_DIR} ${PREFIX}/bin ${PREFIX}/share/jicofo/lib ${MODJAVA_JAR_DIR}
-	cp ${FILESDIR}/jicofo.sh ${FILESDIR}/jicofo.in.sh ${FILESDIR}/jicofo.conf ${WRKSRC}
-	${SUBST_CMD} ${WRKSRC}/jicofo.sh ${WRKSRC}/jicofo.in.sh
-	${INSTALL_PROGRAM} ${WRKSRC}/jicofo.sh ${PREFIX}/bin/jicofo
-	${INSTALL_DATA} ${WRKSRC}/jicofo.conf ${PREFIX}/share/jicofo/
-	${INSTALL_DATA} ${WRKSRC}/jicofo.in.sh ${PREFIX}/share/jicofo/
-	${INSTALL_DATA} ${WRKSRC}/lib/logging.properties ${PREFIX}/share/jicofo/lib/
+	${SUBST_PROGRAM} ${FILESDIR}/jicofo.sh ${PREFIX}/bin/jicofo
+	${SUBST_DATA} ${FILESDIR}/jicofo.in.sh ${PREFIX}/share/jicofo/jicofo.in.sh \
+	    ${FILESDIR}/jicofo.conf ${PREFIX}/share/jicofo/jicofo.conf.sample
+	${INSTALL_DATA} ${WRKSRC}/lib/logging.properties \
+	    ${PREFIX}/share/jicofo/lib/logging.properties.sample
 	${INSTALL_DATA} ${WRKSRC}/target/jicofo-1.1-SNAPSHOT-jar-with-dependencies.jar ${MODJAVA_JAR_DIR}/jicofo.jar
 
 .include <bsd.port.mk>

--- a/net/jicofo/pkg/PLIST
+++ b/net/jicofo/pkg/PLIST
@@ -5,9 +5,10 @@ share/java/
 share/java/classes/
 share/java/classes/jicofo.jar
 share/jicofo/
-share/jicofo/jicofo.conf
+share/jicofo/jicofo.conf.sample
 @sample ${SYSCONFDIR}/jicofo/jicofo.conf
 share/jicofo/jicofo.in.sh
 @sample ${SYSCONFDIR}/jicofo/jicofo.in.sh
 share/jicofo/lib/
-share/jicofo/lib/logging.properties
+share/jicofo/lib/logging.properties.sample
+@sample share/jicofo/lib/logging.properties

--- a/net/jicofo/pkg/PLIST
+++ b/net/jicofo/pkg/PLIST
@@ -7,7 +7,7 @@ share/java/classes/jicofo.jar
 share/jicofo/
 share/jicofo/jicofo.conf.sample
 @sample ${SYSCONFDIR}/jicofo/jicofo.conf
-share/jicofo/jicofo.in.sh
+share/jicofo/jicofo.in.sh.sample
 @sample ${SYSCONFDIR}/jicofo/jicofo.in.sh
 share/jicofo/lib/
 share/jicofo/lib/logging.properties.sample

--- a/net/jitsi-videobridge/Makefile
+++ b/net/jitsi-videobridge/Makefile
@@ -3,13 +3,13 @@ COMMENT =	WebRTC compatible video router for jitsi
 CATEGORIES =	net
 
 VERSION =	2.0.7648
-PKGNAME =	jitsi-videobridge-${VERSION}
+DISTNAME =	jitsi-videobridge-${VERSION}
 
 GH_ACCOUNT =	jitsi
 GH_PROJECT =	jitsi-videobridge
 GH_COMMIT =	42bc1b9986b375e4e9d5044585f6bd0604bf8d25
 
-DISTFILES +=	jitsi-videobridge-${VERSION}{${GH_COMMIT}}${EXTRACT_SUFX}
+DISTFILES +=	${GH_DISTFILE}
 
 # vendor maven dependencies
 MASTER_SITES7 =	https://files.bsd.ac/openbsd-distfiles/
@@ -34,7 +34,7 @@ MAVEN_REPO=	-Dmaven.repo.local=${WRKDIR}/m2
 
 do-build:
 	cd ${WRKSRC} && \
-		env -i ${MAKE_ENV} mvn ${MAVEN_REPO} ${MAVEN_ARGS} package
+		${SETENV} ${MAKE_ENV} mvn ${MAVEN_REPO} ${MAVEN_ARGS} package
 
 do-install:
 	${INSTALL_DATA_DIR} ${PREFIX}/bin ${PREFIX}/share/jvb/lib/ ${MODJAVA_JAR_DIR}
@@ -46,6 +46,5 @@ do-install:
 	${INSTALL_DATA} ${WRKSRC}/sip-communicator.properties ${PREFIX}/share/jvb/lib/
 	${INSTALL_DATA} ${WRKSRC}/jvb/lib/logging.properties ${PREFIX}/share/jvb/lib/
 	${INSTALL_DATA} ${WRKSRC}/jvb/target/jitsi-videobridge-2.1-SNAPSHOT-jar-with-dependencies.jar ${MODJAVA_JAR_DIR}/jitsi-videobridge.jar
-
 
 .include <bsd.port.mk>

--- a/net/jitsi-videobridge/Makefile
+++ b/net/jitsi-videobridge/Makefile
@@ -38,13 +38,11 @@ do-build:
 
 do-install:
 	${INSTALL_DATA_DIR} ${PREFIX}/bin ${PREFIX}/share/jvb/lib/ ${MODJAVA_JAR_DIR}
-	cp ${FILESDIR}/jvb.sh ${FILESDIR}/jvb.in.sh ${FILESDIR}/jvb.conf ${FILESDIR}/sip-communicator.properties ${WRKSRC}
-	${SUBST_CMD} ${WRKSRC}/jvb.sh ${WRKSRC}/jvb.in.sh
-	${INSTALL_PROGRAM} ${WRKSRC}/jvb.sh ${PREFIX}/bin/jvb
-	${INSTALL_DATA} ${WRKSRC}/jvb.conf ${PREFIX}/share/jvb/
-	${INSTALL_DATA} ${WRKSRC}/jvb.in.sh ${PREFIX}/share/jvb/
-	${INSTALL_DATA} ${WRKSRC}/sip-communicator.properties ${PREFIX}/share/jvb/lib/
-	${INSTALL_DATA} ${WRKSRC}/jvb/lib/logging.properties ${PREFIX}/share/jvb/lib/
+	${SUBST_PROGRAM} ${FILESDIR}/jvb.sh ${PREFIX}/bin/jvb
+	${SUBST_DATA} ${FILESDIR}/jvb.in.sh ${PREFIX}/share/jvb/jvb.in.sh.sample \
+	    ${FILESDIR}/jvb.conf ${PREFIX}/share/jvb/jvb.conf.sample \
+	    ${FILESDIR}/sip-communicator.properties ${PREFIX}/share/jvb/lib/sip-communicator.properties.sample
+	${INSTALL_DATA} ${WRKSRC}/jvb/lib/logging.properties ${PREFIX}/share/jvb/lib/logging.properties.sample
 	${INSTALL_DATA} ${WRKSRC}/jvb/target/jitsi-videobridge-2.1-SNAPSHOT-jar-with-dependencies.jar ${MODJAVA_JAR_DIR}/jitsi-videobridge.jar
 
 .include <bsd.port.mk>

--- a/net/jitsi-videobridge/distinfo
+++ b/net/jitsi-videobridge/distinfo
@@ -1,4 +1,4 @@
-SHA256 (jitsi-videobridge-2.0.7648.tar.gz) = sbXWnz6WsQyZ5E4wfIqKO8nBIACUJFmuDy/REPfkhRk=
+SHA256 (jitsi-videobridge-2.0.7648-42bc1b99.tar.gz) = sbXWnz6WsQyZ5E4wfIqKO8nBIACUJFmuDy/REPfkhRk=
 SHA256 (jitsi-videobridge-deps-2.0.7648.tgz) = mIEMVYAMGEbkCBm4vcUVZxKuEl5UXeVDFykJZmJnQ/8=
-SIZE (jitsi-videobridge-2.0.7648.tar.gz) = 62357177
+SIZE (jitsi-videobridge-2.0.7648-42bc1b99.tar.gz) = 62357177
 SIZE (jitsi-videobridge-deps-2.0.7648.tgz) = 268595272

--- a/net/jitsi-videobridge/pkg/PLIST
+++ b/net/jitsi-videobridge/pkg/PLIST
@@ -5,11 +5,12 @@ share/java/
 share/java/classes/
 share/java/classes/jitsi-videobridge.jar
 share/jvb/
-share/jvb/jvb.conf
+share/jvb/jvb.conf.sample
 @sample ${SYSCONFDIR}/jvb/jvb.conf
-share/jvb/jvb.in.sh
+share/jvb/jvb.in.sh.sample
 @sample ${SYSCONFDIR}/jvb/jvb.in.sh
 share/jvb/lib/
-share/jvb/lib/logging.properties
-share/jvb/lib/sip-communicator.properties
+share/jvb/lib/logging.properties.sample
+@sample share/jvb/lib/logging.properties
+share/jvb/lib/sip-communicator.properties.sample
 @sample ${SYSCONFDIR}/jvb/sip-communicator.properties

--- a/www/jitsi-meet/Makefile
+++ b/www/jitsi-meet/Makefile
@@ -1,11 +1,10 @@
-COMMENT =	Web files for Jitsi Meet
+COMMENT =	web files for Jitsi Meet
 
 CATEGORIES =	www
 
 VERSION =	1.0.6542
 MASTER_SITES =	https://download.jitsi.org/jitsi-meet/src/
-PKGNAME =	jitsi-meet-${VERSION}
-DISTNAME =	${PKGNAME}
+DISTNAME =	jitsi-meet-${VERSION}
 EXTRACT_SUFX =	.tar.bz2
 
 MAINTAINER =	Philipp Buehler <pb-openbsd@sysfive.com>, \
@@ -27,6 +26,5 @@ post-extract:
 do-install:
 	${INSTALL_DATA_DIR} ${INSTDIR}
 	cp -R ${WRKDIR}/jitsi-meet/ ${INSTDIR}
-
 
 .include <bsd.port.mk>


### PR DESCRIPTION
- make it clearer which installed files are `@sample`'d
- use SUBST_(DATA/PROGRAM) instead of cp + SUBST_CMD + INSTALL_(DATA/PROGRAM)
- use GH_DISTFILE construct when building DISTFILES